### PR TITLE
ci: stop testing against NodeJS v10, v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,9 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 10
-          - 12
           - 14
           - 16
+          - 18
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
         "@pika/plugin-ts-standard-pkg"
       ],
       [
-        "@pika/plugin-build-node"
+        "@pika/plugin-build-node",
+        {
+          "minNodeVersion": "14"
+        }
       ],
       [
         "@pika/plugin-build-web"
@@ -81,5 +84,8 @@
     "extends": [
       "github>octokit/.github"
     ]
+  },
+  "engines": {
+    "node": ">= 14"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v10, v12