### PR TITLE
ci: stop testing against NodeJS v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 18
           - 20
           - 22
+          - 24
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node_version }}

--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
     "provenance": true
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v18